### PR TITLE
Added missing cfg variable and DNS is set before uninstalling ADDC

### DIFF
--- a/lib/Modules/ADHooks/ADHooks.psm1
+++ b/lib/Modules/ADHooks/ADHooks.psm1
@@ -984,6 +984,7 @@ function Remove-UnitFromDomain {
         Remove-CharmState -Namespace "AD" -Key "nameservers" | Out-Null
     }
 
+    $cfg = Get-JujuCharmConfig
     $adminName = Get-AdministratorAccount
     $localAdmin = "{0}\{1}" -f @($COMPUTERNAME, $adminName)
     $adminSecurePass = ConvertTo-SecureString $cfg['administrator-password'] -AsPlainText -Force
@@ -1255,11 +1256,11 @@ function Invoke-StopHook {
         return
     }
 
+    Set-DNSToMainDomainController
+
     if(Get-IsDomainController) {
         Uninstall-ADDC
     }
-
-    Set-DNSToMainDomainController
 
     $isCollocatedCharm = Get-IsAnotherCharmCollocated -CurrentComputerName $COMPUTERNAME
     if($isCollocatedCharm) {


### PR DESCRIPTION
After demoting the domain controller, the machine reboots and it
is simply joined to the domain. We need to set the proper
DNS to another domain before uninstalling the ADDC, otherwise
the stop hook will fail because machine can't reach the domain.