### PR TITLE
Transfer FSMO roles to the leader when a FSMO role holding unit disappears from the unit inventory

### DIFF
--- a/hooks/update-status.ps1
+++ b/hooks/update-status.ps1
@@ -1,0 +1,28 @@
+# Copyright 2016 Cloudbase Solutions Srl
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+#
+
+$ErrorActionPreference = "Stop"
+
+Import-Module JujuLogging
+
+
+try {
+    Import-Module ADHooks
+
+    Invoke-UpdateStatusHook
+} catch {
+    Write-HookTracebackToLog $_
+    exit 1
+}

--- a/lib/Modules/ADHooks/ADHooks.psd1
+++ b/lib/Modules/ADHooks/ADHooks.psd1
@@ -42,7 +42,8 @@ FunctionsToExport = @(
     "Invoke-ADJoinRelationDepartedHook",
     "Invoke-ADPeerRelationChangedHook",
     "Invoke-ADDNSRelationChangedHook",
-    "Invoke-ADSPNRelationChangedHook")
+    "Invoke-ADSPNRelationChangedHook",
+    "Invoke-UpdateStatusHook")
 
 # Variables to export from this module
 VariablesToExport = '*'

--- a/lib/Modules/ADHooks/ADHooks.psm1
+++ b/lib/Modules/ADHooks/ADHooks.psm1
@@ -149,7 +149,7 @@ function Close-ADDCPorts {
 function Get-CharmDomain {
     <#
     .SYNOPSIS
-    Returns the fully qualified domain name for this active directory deployment.   
+    Returns the fully qualified domain name for this active directory deployment.
     #>
     $cfg = Get-JujuCharmConfig
 
@@ -1166,6 +1166,98 @@ function Add-ComputerToADGroupDeprecated {
     }
 }
 
+function Get-FSMORoles {
+    <#
+    .SYNOPSIS
+    Retrieves the FSMO role holders from one or more Active Directory domains and forests.
+    .DESCRIPTION
+    Get-FSMORoles uses the Get-ADDomain and Get-ADForest Active Directory cmdlets to determine
+    which domain controller currently holds each of the Active Directory FSMO roles.
+    .PARAMETER DomainName
+    One or more Active Directory domain names.
+    .EXAMPLE
+    Get-Content domainnames.txt | Get-FSMORoles
+    .EXAMPLE
+    Get-FSMORoles -DomainName domain1, domain2
+    #>
+    [CmdletBinding()]
+    param(
+        [Parameter(ValueFromPipeline=$True)]
+        [string[]]$DomainName = $env:USERDOMAIN
+    )
+    BEGIN {
+        Import-Module ActiveDirectory -Cmdlet Get-ADDomain, Get-ADForest -ErrorAction SilentlyContinue
+    }
+    PROCESS {
+        foreach ($domain in $DomainName) {
+            Write-JujuInfo "Querying $domain"
+            Try {
+            $problem = $false
+            $addomain = Get-ADDomain -Identity $domain -ErrorAction Stop
+            } Catch { $problem = $true
+            Write-JujuWarning $_.Exception.Message
+            }
+            if (-not $problem) {
+                $adforest = Get-ADForest -Identity (($addomain).forest)
+
+                return @{
+                    InfrastructureMaster = $addomain.InfrastructureMaster
+                    PDCEmulator = $addomain.PDCEmulator
+                    RIDMaster = $addomain.RIDMaster
+                    DomainNamingMaster = $adforest.DomainNamingMaster
+                    SchemaMaster = $adforest.SchemaMaster
+                }
+            }
+        }
+    }
+}
+
+function Remove-ADComputerFromADForest {
+    Param(
+        [Parameter(Mandatory=$true)]
+        [string]$Computer
+    )
+
+    if($Computer -eq ""){
+        Write-JujuWarning "You need to specify a name to delete"
+        return
+    }
+
+    $cfg = Get-JujuCharmConfig
+    $domainCreds = Get-DomainCredential -UserName $cfg['domain-user'] -Password $cfg['domain-user-password']
+
+    [array]$adminNames = Get-AdministratorAccount
+    $adminName = $adminNames[0]
+    $cfg = Get-JujuCharmConfig
+    $domainCredential = Get-DomainCredential -UserName $adminName -Password $cfg['administrator-password']
+
+    $computerObject = Get-ADComputer -Identity $Computer
+    if($computerObject) {
+        Write-JujuWarning "Removing $Computer from AD domain"
+        $computerObject | Remove-ADObject -Recursive -Confirm:$false -Credential $domainCredential -ErrorAction SilentlyContinue | Out-Null
+    }
+
+    $ZoneName = Get-CharmDomain
+    $DNSResources = $null
+    $DNSResources = Get-DnsServerResourceRecord -ZoneName $ZoneName -Node $Computer -ErrorAction SilentlyContinue
+    if($DNSResources -eq $null){
+        Write-JujuWarning "No DNS record found"
+    } else {
+        foreach ($record in $DNSResources)
+        {
+            Remove-DnsServerResourceRecord -ZoneName $ZoneName -InputObject $record -Force -ErrorAction Stop
+        }
+    }
+}
+
+function Start-TransferFSMORoles {
+    $currentMachineName = [System.Net.Dns]::GetHostName()
+    $cfg = Get-JujuCharmConfig
+    Write-JujuWarning 'Transferring FSMO roles to leader'
+    Move-ADDirectoryServerOperationMasterRole -Identity $currentMachineName -OperationMasterRole 0,1,2,3,4 -Force -Confirm:$false -ErrorAction Stop
+    Write-JujuWarning 'FSMO roles transferred'
+}
+
 
 # HOOKS METHODS
 
@@ -1457,4 +1549,53 @@ function Invoke-ADSPNRelationChangedHook {
             }
         }
     }
+}
+
+function Invoke-UpdateStatusHook {
+    if(!(Confirm-Leader)){
+        Write-JujuWarning "Unit is not leader. Skipping the rest of the hook"
+        return
+    } else {
+        $rids = Get-JujuRelationIds -Relation 'ad-peer'
+
+        $computerNames = @(
+            $COMPUTERNAME)
+        foreach($rid in $rids) {
+            $units = Get-JujuRelatedUnits -RelationId $rid
+            foreach($unit in $units) {
+                $computerAddress = Get-JujuRelation -RelationId $rid -Unit $unit -Attribute 'private-address'
+                $computer = [System.Net.Dns]::GetHostByAddress([string]$computerAddress).HostName
+                if($computer -and ($computer -notIn $computerNames)) {
+                    $computerNames += $computer
+                }
+            }
+        }
+
+        $ADComputers = (Get-ADComputer -Filter *).Name
+        $FSMOComputers = (Get-FSMORoles).Values
+        $ADDomain = Get-CharmDomain
+        $FSMOTransferNeeded = $false
+        $ComputersToRemove = @()
+
+        foreach ($ADComputer in $ADComputers)
+        {
+            $FQDNComputer = "{0}.{1}" -f @($ADComputer, $ADDomain)
+            if($ADComputer -notIn $computerNames){
+                $ComputersToRemove += $ADComputer
+                Write-JujuWarning "Machine $ADComputer is not in the cluster anymore. Queuing for removal..."
+                if ($FQDNComputer -in $FSMOComputers){
+                    $FSMOTransferNeeded = $true
+                }
+            }
+        }
+
+        if($FSMOTransferNeeded){
+            Start-TransferFSMORoles
+        }
+
+        foreach($computer in $ComputersToRemove){
+            Remove-ADComputerFromADForest -Computer $computer
+        }
+    }
+
 }


### PR DESCRIPTION
Transfer FSMO roles to the leader when a FSMO role holding unit departs (FSMO roles seizing); remove departed units from AD and DNS