### PR TITLE
Fixed ad-join relation when there are no units in the relation

### DIFF
--- a/lib/Modules/ADHooks/ADHooks.psm1
+++ b/lib/Modules/ADHooks/ADHooks.psm1
@@ -1457,7 +1457,10 @@ function Invoke-ADJoinRelationChangedHook {
 
     $rids = Get-JujuRelationIds -Relation 'ad-join'
     foreach($rid in $rids) {
-        $units = Get-JujuRelatedUnits -RelationId $rid
+        [array]$units = Get-JujuRelatedUnits -RelationId $rid
+        if(!$units.Count) {
+            continue
+        }
         foreach($unit in $units) {
             $relationSettings = New-ADJoinRelationData -RelationId $rid -Unit $unit
             Set-JujuRelation -RelationId $rid -Settings $relationSettings


### PR DESCRIPTION
Do not continue to do any logic if there are no units set in the
'ad-join' relation. This doesn't break the code as Set-NodesKCD
require a non-empty list of units and also improves performance.